### PR TITLE
chore(gitignore): add vscode and intellij ide folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 
+.idea/
+.vscode/
+
 .yarn/*
 !.yarn/patches
 !.yarn/plugins


### PR DESCRIPTION
Ignores the folders that are created when using Visual Studio Code or IntelliJ or Webstorm IDE's